### PR TITLE
Define exit keys and improve readme and user messages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,20 @@ to install commit-email.
 ```sh
 cargo install commit-email
 ```
+
+## Configure
+
+If you want do adjust the config file for the `commit-email` tool, you will find the configs in the following path `~/.config/commit-email/commit-email.toml` (linux).
+
+```toml
+# List of repo urls where the tool will not set a commit email
+ignore = []
+
+# Emails the tool will use
+emails = [
+    'email@example.com',
+    'email2@example.com'
+]
+```
+
+The tool will also use your global git email, if set (e.g. in your global `.gitconfig`).

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
                     break repo;
                 }
             }
-            None => bail!("Test"),
+            None => bail!("Not in a repo"),
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use config::Config;
+use cursive::event::Key;
 use cursive::views::{Dialog, SelectView};
 use cursive::Cursive;
 use repo::Repo;
@@ -40,6 +41,8 @@ fn main() -> Result<()> {
     // Create UI
     let mut ui = cursive::crossterm();
     ui.load_toml(include_str!("../assets/style.toml")).unwrap();
+    ui.add_global_callback(Key::Esc, |app| app.quit());
+    ui.add_global_callback('q', |app| app.quit());
 
     let mut sv = SelectView::new();
     sv.add_all(config.get_emails());


### PR DESCRIPTION
**This PR does multiple things:**
* Fix a clippy issue
* Extend the readme with informations about how the user can configure the tool.
* Improve messages displayed to the user in cases where the tool should not behave as expected
* Add a small new feature

**New Features**
* Add exit keys. So instead to cancel the hard way with `STRG & c` you can now exit cautious by pressing the ESC key or `q`