### PR TITLE
Update rust edition from 2018 to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "A tool that reminds you to commit with the correct email address"
 repository = "https://github.com/mkqavi/commit-email"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR updated the used rust edition in this project from 2018 to 2021.

I followed the migration steps provided in the rust [edition guide](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html)

- [x] Run `cargo fix --edition` and commit fixes (in this case no fixes were required)
- [x] Edit version in `cargo.toml`
- [x] Verify build and tests

Close #35 