### PR TITLE
refactor(deps): Bump git2 from 0.20.4 to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,17 +347,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -556,15 +553,13 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -576,20 +571,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags",
  "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -732,24 +713,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-git2 = "0.20.4"
+git2 = "0.21.0"
 dirs = "6.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
 toml = "1.1.2"

--- a/flake.nix
+++ b/flake.nix
@@ -45,10 +45,6 @@
             packages = with pkgs; [
               rustToolchain
 
-              # Required by openssl-sys crate
-              pkg-config
-              openssl
-
               nil
               nixfmt
             ];

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -29,7 +29,7 @@ impl Repo {
         let email_entry = config.get_entry("user.email").ok()?;
 
         match email_entry.level() {
-            ConfigLevel::Local => email_entry.value().map(|s| s.to_string()),
+            ConfigLevel::Local => email_entry.value().ok().map(|s| s.to_string()),
             _ => None,
         }
     }
@@ -52,13 +52,13 @@ impl Repo {
 
         let remote = match locked_repo.find_remote("origin") {
             Ok(remote) => remote,
-            Err(_) => match locked_repo.remotes().ok()?.get(0) {
+            Err(_) => match locked_repo.remotes().ok()?.get(0).ok()? {
                 Some(remote_name) => locked_repo.find_remote(remote_name).ok()?,
                 None => return None,
             },
         };
 
-        Repo::parse_url_string(remote.url()?)
+        Repo::parse_url_string(remote.url().ok()?)
     }
 
     fn parse_url_string(url_string: &str) -> Option<Url> {


### PR DESCRIPTION
This also includes the necessary adjustments in the `repo.rs` to handle
the new errors returned by `git2`.

Bumps [git2](https://github.com/rust-lang/git2-rs) from 0.20.4 to 0.21.0.
- [Changelog](https://github.com/rust-lang/git2-rs/blob/main/CHANGELOG.md)
- [Commits](https://github.com/rust-lang/git2-rs/compare/git2-0.20.4...git2-0.21.0)

---
updated-dependencies:
- dependency-name: git2
  dependency-version: 0.21.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
...
